### PR TITLE
chore(Dockerfile): mv pg run path to /postgresql

### DIFF
--- a/make/photon/db/Dockerfile.base
+++ b/make/photon/db/Dockerfile.base
@@ -6,12 +6,12 @@ RUN tdnf install -y shadow gzip postgresql >> /dev/null\
     && groupadd -r postgres --gid=999 \
     && useradd -m -r -g postgres --uid=999 postgres \
     && mkdir -p /docker-entrypoint-initdb.d \
-    && mkdir -p /run/postgresql \
-    && chown -R postgres:postgres /run/postgresql \
-    && chmod 2777 /run/postgresql \
+    && mkdir -p /postgresql \
+    && chown -R postgres:postgres /postgresql \
+    && chmod 2777 /postgresql \
     && mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" \
     && sed -i "s|#listen_addresses = 'localhost'.*|listen_addresses = '*'|g" /usr/share/postgresql/postgresql.conf.sample \
-    && sed -i "s|#unix_socket_directories = '/tmp'.*|unix_socket_directories = '/run/postgresql'|g" /usr/share/postgresql/postgresql.conf.sample \
+    && sed -i "s|#unix_socket_directories = '/tmp'.*|unix_socket_directories = '/postgresql'|g" /usr/share/postgresql/postgresql.conf.sample \
     && tdnf clean all
 
 RUN tdnf erase -y toybox && tdnf install -y util-linux net-tools

--- a/make/photon/db/docker-entrypoint.sh
+++ b/make/photon/db/docker-entrypoint.sh
@@ -67,7 +67,7 @@ EOF
         file_env 'POSTGRES_USER' 'postgres'
         file_env 'POSTGRES_DB' "$POSTGRES_USER"
 
-        psql=( psql -v ON_ERROR_STOP=1 )
+        psql=( psql -h /postgresql -v ON_ERROR_STOP=1 )
 
         if [ "$POSTGRES_DB" != 'postgres' ]; then
                 "${psql[@]}" --username postgres <<-EOSQL


### PR DESCRIPTION
Using containerd as runtime, it will mount /run as tmpfs. So, change PG run path to /postgresql.

/cc @zhujian7 